### PR TITLE
feat: add reusable product list and new card design

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -12,15 +12,8 @@
   --font-mono: var(--font-geist-mono);
 }
 
-@media (prefers-color-scheme: dark) {
-  :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
-  }
-}
-
 body {
-  background: var(--background);
+  background: #ffffff;
   color: var(--foreground);
   font-family: Arial, Helvetica, sans-serif;
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -25,7 +25,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body
-        className={`${geistSans.variable} ${geistMono.variable} antialiased`}
+        className={`${geistSans.variable} ${geistMono.variable} antialiased bg-white`}
       >
         {children}
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,72 +1,9 @@
-import ProductCard, { Product } from "@/components/ProductCard";
-
-const products: Product[] = [
-  {
-    id: 1,
-    title: "Product 1",
-    description: "Description for product 1",
-    price: "$10",
-    image: "https://via.placeholder.com/300",
-  },
-  {
-    id: 2,
-    title: "Product 2",
-    description: "Description for product 2",
-    price: "$20",
-    image: "https://via.placeholder.com/300",
-  },
-  {
-    id: 3,
-    title: "Product 3",
-    description: "Description for product 3",
-    price: "$30",
-    image: "https://via.placeholder.com/300",
-  },
-  {
-    id: 4,
-    title: "Product 4",
-    description: "Description for product 4",
-    price: "$40",
-    image: "https://via.placeholder.com/300",
-  },
-  {
-    id: 5,
-    title: "Product 5",
-    description: "Description for product 5",
-    price: "$50",
-    image: "https://via.placeholder.com/300",
-  },
-  {
-    id: 6,
-    title: "Product 6",
-    description: "Description for product 6",
-    price: "$60",
-    image: "https://via.placeholder.com/300",
-  },
-  {
-    id: 7,
-    title: "Product 7",
-    description: "Description for product 7",
-    price: "$70",
-    image: "https://via.placeholder.com/300",
-  },
-  {
-    id: 8,
-    title: "Product 8",
-    description: "Description for product 8",
-    price: "$80",
-    image: "https://via.placeholder.com/300",
-  },
-];
+import ProductList from "@/components/ProductList";
 
 export default function Home() {
   return (
-    <main className="p-8">
-      <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-4 gap-6">
-        {products.map((product) => (
-          <ProductCard key={product.id} product={product} />
-        ))}
-      </div>
+    <main className="p-8 bg-white">
+      <ProductList apiUrl="https://dummyjson.com/products" />
     </main>
   );
 }

--- a/src/app/product/[id]/page.tsx
+++ b/src/app/product/[id]/page.tsx
@@ -1,6 +1,6 @@
 export default function Page() {
   return (
-    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20">
+    <div className="font-sans grid grid-rows-[20px_1fr_20px] items-center justify-items-center min-h-screen p-8 pb-20 gap-16 sm:p-20 bg-white">
       This is a product detail page.
     </div>
   );

--- a/src/components/ProductCard.tsx
+++ b/src/components/ProductCard.tsx
@@ -1,26 +1,47 @@
 import Image from "next/image";
+import Link from "next/link";
 
 export type Product = {
   id: number;
   title: string;
   description: string;
-  price: string;
+  price: string | number;
   image: string;
 };
 
 export default function ProductCard({ product }: { product: Product }) {
   return (
-    <div className="border rounded-lg p-4 flex flex-col">
-      <Image
-        src={product.image}
-        alt={product.title}
-        width={300}
-        height={200}
-        className="mb-4 w-full h-auto object-cover"
-      />
-      <h3 className="text-lg font-semibold">{product.title}</h3>
-      <p className="text-sm text-gray-600 flex-grow">{product.description}</p>
-      <p className="mt-2 font-bold">{product.price}</p>
+    <div className="bg-white border rounded-lg p-3 flex flex-col transition-shadow hover:shadow-md">
+      <Link href={`/product/${product.id}`} className="flex flex-col flex-grow">
+        <div className="relative w-full aspect-square mb-3">
+          <Image
+            src={product.image}
+            alt={product.title}
+            fill
+            className="object-contain p-2"
+          />
+        </div>
+        <h3 className="text-sm font-medium text-gray-800 line-clamp-2 min-h-[2.5rem]">
+          {product.title}
+        </h3>
+      </Link>
+      <div className="mt-2 flex items-center justify-between">
+        <span className="font-semibold text-red-600">
+          {typeof product.price === "number" ? product.price.toLocaleString() : product.price}
+        </span>
+        <button
+          aria-label="Add to favourites"
+          className="text-gray-400 hover:text-red-500 transition-colors"
+        >
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            viewBox="0 0 24 24"
+            className="w-5 h-5 fill-current"
+          >
+            <path d="M12 21.35l-1.45-1.32C5.4 15.36 2 12.28 2 8.5 2 5.42 4.42 3 7.5 3c1.74 0 3.41.81 4.5 2.09C13.09 3.81 14.76 3 16.5 3 19.58 3 22 5.42 22 8.5c0 3.78-3.4 6.86-8.55 11.54L12 21.35z" />
+          </svg>
+        </button>
+      </div>
     </div>
   );
 }

--- a/src/components/ProductList.tsx
+++ b/src/components/ProductList.tsx
@@ -1,0 +1,59 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import ProductCard, { Product } from "./ProductCard";
+
+interface ProductListProps {
+  apiUrl: string;
+  className?: string;
+}
+
+export default function ProductList({ apiUrl, className }: ProductListProps) {
+  const [products, setProducts] = useState<Product[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    let ignore = false;
+    async function load() {
+      try {
+        const res = await fetch(apiUrl);
+        const data = await res.json();
+        const items: Array<Record<string, unknown>> = Array.isArray(data)
+          ? data
+          : data.products || [];
+        if (!ignore) {
+          setProducts(
+            items.map((p) => ({
+              id: Number(p.id),
+              title: String(p.title),
+              description: String(p.description),
+              price: p.price as number,
+              image: (p.image || p.thumbnail || "") as string,
+            }))
+          );
+        }
+      } catch (e) {
+        console.error(e);
+      } finally {
+        if (!ignore) setLoading(false);
+      }
+    }
+    load();
+    return () => {
+      ignore = true;
+    };
+  }, [apiUrl]);
+
+  if (loading) {
+    return <div>Loading...</div>;
+  }
+
+  return (
+    <div className={`grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-6 ${className ?? ""}`}>
+      {products.map((product) => (
+        <ProductCard key={product.id} product={product} />
+      ))}
+    </div>
+  );
+}
+


### PR DESCRIPTION
## Summary
- redesign ProductCard with image aspect ratio, price styling and favourite icon
- add generic ProductList component driven by API URL and use it on the home page
- enforce white backgrounds across layout and pages

## Testing
- `npm run lint`
- `npm run build` *(fails: Failed to fetch font `Geist`)*

------
https://chatgpt.com/codex/tasks/task_e_689f53d3cf8c8324b5a9ff27155c55e7